### PR TITLE
Add the ability to filter messages by username

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -32,6 +32,12 @@
         </select>
       </div>
       
+      <div> <!-- needed to stop the select from messing up -->
+        <select id="opt-messages-by-user">
+          <option value="">Filter messages by user&nbsp;</option>
+        </select>
+      </div>
+
       <div class="nav">
         <button id="nav-first" data-nav="first">&laquo;</button>
         <button id="nav-prev" data-nav="prev">&lsaquo;</button>

--- a/src/renderer/scr.exec.js
+++ b/src/renderer/scr.exec.js
@@ -26,6 +26,10 @@ document.addEventListener("DOMContentLoaded", () => {
   
   STATE.setMessagesPerPage(GUI.getOptionMessagesPerPage());
   
+  GUI.onOptionMessagesByUserChanged(() => {
+    STATE.setMessagesByUser(GUI.getOptionMessagesByUser());
+  });
+
   GUI.onNavigationButtonClicked(action => {
     STATE.updateCurrentPage(action);
   });
@@ -38,5 +42,9 @@ document.addEventListener("DOMContentLoaded", () => {
     GUI.updateNavigation(STATE.getCurrentPage(), STATE.getPageCount());
     GUI.updateMessageList(messages);
     GUI.scrollMessagesToTop();
+  });
+
+  STATE.onUsersRefreshed(users => {
+    GUI.updateUserFilter(users);
   });
 });

--- a/src/renderer/scr.gui.js
+++ b/src/renderer/scr.gui.js
@@ -1,6 +1,7 @@
 var GUI = (function(){
   var eventOnFileUploaded;
   var eventOnOptMessagesPerPageChanged;
+  var eventOnOptMessagesByUserChanged;
   var eventOnNavButtonClicked;
   
   var showModal = function(width, html){
@@ -73,6 +74,10 @@ var GUI = (function(){
         eventOnOptMessagesPerPageChanged && eventOnOptMessagesPerPageChanged();
       });
       
+      DOM.id("opt-messages-by-user").addEventListener("change", () => {
+        eventOnOptMessagesByUserChanged && eventOnOptMessagesByUserChanged();
+      });
+
       DOM.tag("button", DOM.fcls("nav")).forEach(button => {
         button.disabled = true;
         
@@ -114,6 +119,13 @@ var GUI = (function(){
     },
     
     /*
+     * Sets a callback for when the user changes the messages by user option. The callback is not passed any arguments.
+     */
+    onOptionMessagesByUserChanged: function(callback){
+      eventOnOptMessagesByUserChanged = callback;
+    },
+
+    /*
      * Sets a callback for when the user clicks a navigation button. The callback is passed one of the following strings: first, prev, next, last.
      */
     onNavigationButtonClicked: function(callback){
@@ -131,6 +143,13 @@ var GUI = (function(){
       return parseInt(DOM.id("opt-messages-per-page").value, 10);
     },
     
+    /*
+     * Returns the user which to filter messages by.
+     */
+    getOptionMessagesByUser: function(){
+      return DOM.id("opt-messages-by-user").value;
+    },
+
     /*
      * Updates the navigation text and buttons.
      */
@@ -158,7 +177,7 @@ var GUI = (function(){
         eleChannels.innerHTML = "";
       }
       else{
-        eleChannels.innerHTML = channels.map(channel => DISCORD.getChannelHTML(channel)).join("");
+        eleChannels.innerHTML = channels.filter(channel => channel.msgcount > 0).map(channel => DISCORD.getChannelHTML(channel)).join("");
         
         Array.prototype.forEach.call(eleChannels.children, ele => {
           ele.addEventListener("click", e => {
@@ -186,6 +205,34 @@ var GUI = (function(){
       DOM.id("messages").innerHTML = messages ? messages.map(message => DISCORD.getMessageHTML(message)).join("") : "";
     },
     
+    /*
+     * Updates the select box with all possibly user names.
+     */
+    updateUserFilter: function(users){
+      var select = DOM.id("opt-messages-by-user");
+
+      // Remove all but first option
+      for (var i = select.length; i > 0; i--) {
+        select.remove(i);
+      }
+
+      var options = [];
+      for (var key in users) {
+        // Skip loop if the property is from prototype
+        if (!users.hasOwnProperty(key)) continue;
+
+        var option = document.createElement("option");
+        option.value = key;
+        option.text = users[key].name;
+        options.push(option);
+      }
+      options.sort((a, b) => {
+        return a.text.toLowerCase().localeCompare(b.text.toLowerCase());
+      }).forEach(option => {
+        select.add(option);
+      });
+    },
+
     /*
      * Scrolls the message div to the top.
      */

--- a/src/renderer/scr.savefile.js
+++ b/src/renderer/scr.savefile.js
@@ -38,6 +38,16 @@ SAVEFILE.prototype.getMessageCount = function(channel){
   return Object.keys(this.getMessages(channel)).length;
 };
 
+SAVEFILE.prototype.getFilteredMessageCount = function(channel, userindex){
+  if (userindex === -1) return this.getMessageCount(channel);
+
+  var count = 0;
+  UTILS.forEachValue(this.getMessages(channel), messageObject => {
+    if (messageObject.u === userindex) count++;
+  });
+  return count;
+};
+
 SAVEFILE.prototype.getAllMessages = function(){
   var messages = {};
   


### PR DESCRIPTION
Selecting a username will only display messages from that person in the messages view. The pagination control is updated to reflect the new maximum page count, and the channel list is updated to show accurate message counts (and will hide channels with no messages).