### PR TITLE
Fix "selected channel not visible in channel list"

### DIFF
--- a/src/tracker/discord.js
+++ b/src/tracker/discord.js
@@ -87,7 +87,7 @@ var DISCORD = (function(){
             return null;
           }
           
-          var name = Array.prototype.find.call(channel.querySelector("[class|='name']").childNodes, node => node.nodeType === Node.TEXT_NODE).nodeValue;
+          var name = Array.prototype.find.call(channel.querySelector("span[class^='name']").childNodes, node => node.nodeType === Node.TEXT_NODE).nodeValue;
           
           obj = {
             "server": name,


### PR DESCRIPTION
Fix "The selected channel is not visible in the channel list" alert when the channel user play a game supporting Rich Presence.

Step to reproduce:
Try to save a private channel of a user playing a game who support Rich Presence.