### PR TITLE
Fix DHT button to show in Firefox with ViolentMonkey

### DIFF
--- a/src/base/track.user.js
+++ b/src/base/track.user.js
@@ -8,6 +8,7 @@
 // @include      https://discordapp.com/*
 // @run-at       document-idle
 // @grant        none
+// @inject-into auto
 // ==/UserScript==
 
 const start = function(){


### PR DESCRIPTION
Fixes #71 by letting ViolentMonkey change the script context if needed, as in the case with Discord. Details on the issue.