### PR TITLE
Fix channel finding

### DIFF
--- a/src/tracker/discord.js
+++ b/src/tracker/discord.js
@@ -135,9 +135,42 @@ var DISCORD = (function(){
           var channelObj = props.children.props.channel;
           
           if (!channelObj){
+            var channellist = DISCORD.getReactProps(channelListEle).children.props.children.props.children; // may not be complete!
+            if (!channellist) {
+              return null; // no channels?
+            }
+            for (let e of channellist) {
+              if (!e || !e.props) {
+                continue;
+              }
+              if (e.props.channel) {
+                if (e.props.selected == true) {
+                 channelObj = e.props.channel;
+                   break;
+                } else {
+                 continue;
+                }
+             }
+              if (e.props.children) {
+                
+                for (let f of e.props.children) {
+                  if (!f || !f.props.channel) {
+                    continue;
+                  }
+                  if (f.props.selected == true) {
+                    channelObj = f.props.channel;
+                    break;
+                  }
+                }
+              }
+              if (channelObj) {
+                break;
+              }
+            }
+          }
+          if (!channelObj) {
             return null;
           }
-          
           obj = {
             "server": document.querySelector("nav header > h1").innerText,
             "channel": channelObj.name,


### PR DESCRIPTION
There was some sort of update in Discord that would broke the channel metadata finding ability. This patch fixes it my making it loop through the main channel list to get the channel info. A particular nit to note is that if all the channels are not loaded into the channellist array (which is possible, especially if the channel is not on the user's channel display on the left), it will still fail to find it. Maybe a scroller or something that will traverse through all the channels in the lefthand side will suffice to fix this? 