### PR TITLE
Add CORS for Canary and PTB

### DIFF
--- a/app/Server/Service/ServerStartup.cs
+++ b/app/Server/Service/ServerStartup.cs
@@ -16,7 +16,7 @@ namespace DHT.Server.Service {
 
 			services.AddCors(static cors => {
 				cors.AddDefaultPolicy(static builder => {
-					builder.WithOrigins("https://discord.com", "https://discordapp.com").AllowCredentials().AllowAnyMethod().AllowAnyHeader();
+					builder.WithOrigins("https://discord.com", "https://discordapp.com", "https://ptb.discord.com", "https://canary.discord.com").AllowCredentials().AllowAnyMethod().AllowAnyHeader();
 				});
 			});
 		}

--- a/app/Server/Service/ServerStartup.cs
+++ b/app/Server/Service/ServerStartup.cs
@@ -9,6 +9,13 @@ using Microsoft.Extensions.Hosting;
 
 namespace DHT.Server.Service {
 	sealed class Startup {
+		private static readonly string[] AllowedOrigins = {
+			"https://discord.com",
+			"https://ptb.discord.com",
+			"https://canary.discord.com",
+			"https://discordapp.com"
+		};
+
 		public void ConfigureServices(IServiceCollection services) {
 			services.Configure<JsonOptions>(static options => {
 				options.SerializerOptions.NumberHandling = JsonNumberHandling.Strict;
@@ -16,7 +23,7 @@ namespace DHT.Server.Service {
 
 			services.AddCors(static cors => {
 				cors.AddDefaultPolicy(static builder => {
-					builder.WithOrigins("https://discord.com", "https://discordapp.com", "https://ptb.discord.com", "https://canary.discord.com").AllowCredentials().AllowAnyMethod().AllowAnyHeader();
+					builder.WithOrigins(AllowedOrigins).AllowCredentials().AllowAnyMethod().AllowAnyHeader();
 				});
 			});
 		}


### PR DESCRIPTION
**tl;dr** Non-stable releases of Discord throw a hissy fit about [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) with the DHT internal server.
It's because the app's (sub)domain is different - like `https://canary.discord.com`, and that's not included in this one file, so I modified it.

---

### The problem

I kept getting the following console errors (on Desktop/Chromium and Firefox respectively) whenever I pressed <kbd>Start Tracking</kbd>:

> Access to fetch at 'http://127.0.0.1:50000/track-channel' from origin 'https://canary.discord.com' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
>
> `POST http://127.0.0.1:50000/track-channel net::ERR_FAILED`
> *`{status: "ERROR", message: "Failed to fetch"}`*

> Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at _http://127.0.0.1:50000/track-channel_. (Reason: CORS header 'Access-Control-Allow-Origin' missing). Status code: (204). [[Learn more](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowOrigin)]
>
> Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at _http://127.0.0.1:50000/track-channel_. (Reason: CORS request did not succeed). Status code: (null). [[Learn more](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSDidNotSucceed)]
>
> `Object { status: "ERROR", message: "NetworkError when attempting to fetch resource." }`

So I looked into the tracking script, but none of my attempts to fix it worked. After a bit more research, it turns out the problem is on the server side.

### The fix

I'm not very experienced with C#, so I referred to [this](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.cors.infrastructure.corspolicybuilder.withorigins?view=aspnetcore-5.0#microsoft-aspnetcore-cors-infrastructure-corspolicybuilder-withorigins(system-string())) to make sure that `WithOrigins()`'s parameters are just an array. I hope that's right.

Unfortunately I wasn't able to test out my code changes, since I kept running into problems with packages despite having the right version of the SDK, even trying to install them manually didn't work, but I'm sure that's just a skill issue on my part.

The only error code I kept getting was `NU1100`, saying `Unable to resolve` followed by whatever's included in each `.csproj` file as a `<PackageReference>`.

I didn't have time to look into this further to try and fix my dependencies, because I had to back up a server that was about to get deleted on a short notice. So I ran the tracker in this way instead:

### The workaround

The current workaround for this CORS conundrum - without changing anything in DHT's code -  is simply using the stable Discord web app or desktop client for running the tracking script.
I went ahead and tested different release channels to see where the CORS stuff is okay:
- [X] Stable (build 136607) on Edge
- [X] Stable (build 136607) on Firefox
- [ ] PTB (build 136634) on Edge
- [ ] Canary (build 136634) on Edge
- [ ] Canary (build 136621) on Windows (Electron)


So it's clear that the problem was just the domain of the Discord app, and I'm pretty sure this will fix it.

(I haven't tested if the CORS error occurs in the [development version](https://github.com/Discord-Client-Encyclopedia-Management/Discord3rdparties#official-clients) of desktop Discord because I had no clue that was even a thing until today.)

Also, would it be possible to use something like wildcards for this? (such as `https://*.discord.com`)
I'm not sure if the ASP.NET builder stuff supports it, but it might be possible by just writing the response headers manually.