### PR TITLE
Fix tracking, rewrite message detection.

### DIFF
--- a/src/tracker/scripts/discord.js
+++ b/src/tracker/scripts/discord.js
@@ -90,17 +90,16 @@ class DISCORD {
 	 */
 	static getMessageElementProps(ele) {
 		const props = DOM.getReactProps(ele);
-		
-		if (props.children && props.children.length) {
-			for (let i = 3; i < props.children.length; i++) {
-				const childProps = props.children[i].props;
-				
-				if (childProps && "message" in childProps && "channel" in childProps) {
-					return childProps;
-				}
+
+		for (let child of (props.children ?? [])) {
+			if (!child) {
+				continue;
+			}
+			const childProps = child.props;
+			if (childProps && "message" in childProps) {
+				return childProps;
 			}
 		}
-		
 		return null;
 	}
 	


### PR DESCRIPTION
Refactored `DISCORD.getMessageElementProps()`.

Keeps previous behavior:
- Absent/empty `props.children` still returns `null`.
- No matching element in `props.children` still returns `null`.
- Still always returns only one match.
- Still handles `props.children === null`.
- - Is this necessary? Seems to work fine either way.

Changes:
- Now handles `props.children[i].props === null`.
- - Fixes console errors.
- No longer checks for `"channel"` in `childProps`.
- - Fixes #240.
- - I don't know what the original layout of `childProps` was, but this seems to match what it is now.
- No longer hardcoded to skip first three items.
- - I'm not clear on what the reasoning for this was. Is it still needed?

Feel free to pick and choose, or close and rewrite. Null check and removing check for `"channel"` should close #240 either way, without the other changes.